### PR TITLE
Update closeAll function to ensure instance.close() can be executed with...

### DIFF
--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -301,7 +301,9 @@
 				instances = Object.getPrototypeOf(self).instances;
 			for(var key in instances){
 				var instance = instances[key];
-				instance.close();
+				if($.isFunction(instance.close)){
+					instance.close();
+				}
 			};
 		},
 	


### PR DESCRIPTION
...out JS error

The prototype of Array may be changed by others, so at least we have to make sure the instance.close is a Function.
