### PR TITLE
Update the height calculation to include margins.

### DIFF
--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -110,7 +110,7 @@
 			
 			for(i = 0; i < self.$items.length; i++){
 				var $item = self.$items.eq(i);
-				self.maxHeight += $item.outerHeight();
+				self.maxHeight += $item.outerHeight(true);
 				if(self.cutOff == i+1){
 					break;
 				};
@@ -379,7 +379,7 @@
 			var self = this;
 			if(self.focusIndex >= self.cutOff){
 				var $focusItem = self.$items.eq(self.focusIndex),
-					scroll = ($focusItem.outerHeight() * (self.focusIndex + 1)) - self.maxHeight;
+					scroll = ($focusItem.outerHeight(true) * (self.focusIndex + 1)) - self.maxHeight;
 			
 				self.$dropDown.scrollTop(scroll);
 			};


### PR DESCRIPTION
When a user edits the margin for the css with margins, the height calculation did not take that into account. See screenshot http://screencloud.net/v/gcJV

The solution is to set outerHeight(true) as per jQuery docs http://api.jquery.com/outerheight/
