### PR TITLE
Don't call focus method on item click

### DIFF
--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -10,7 +10,7 @@
 
 
 (function($){
-	
+
 	function EasyDropDown(){
 		this.isField = true,
 		this.down = false,
@@ -23,13 +23,13 @@
 		this.wrapperClass = 'dropdown',
 		this.onChange = null;
 	};
-	
+
 	EasyDropDown.prototype = {
 		constructor: EasyDropDown,
 		instances: {},
 		init: function(domNode, settings){
 			var	self = this;
-			
+
 			$.extend(self, settings);
 			self.$select = $(domNode);
 			self.id = domNode.id;
@@ -73,12 +73,12 @@
 				self.render();
 			};
 		},
-	
+
 		render: function(){
 			var	self = this,
 				touchClass = self.isTouch && self.nativeTouch ? ' touch' : '',
 				disabledClass = self.disabled ? ' disabled' : '';
-			
+
 			self.$container = self.$select.wrap('<div class="'+self.wrapperClass+touchClass+disabledClass+'"><span class="old"/></div>').parent().parent();
 			self.$active = $('<span class="selected">'+self.selected.title+'</span>').appendTo(self.$container);
 			self.$carat = $('<span class="carat"/>').appendTo(self.$container);
@@ -91,23 +91,23 @@
 				self.$dropDown.append('<li'+active+'>'+option.title+'</li>');
 			});
 			self.$items = self.$dropDown.find('li');
-			
+
 			if(self.cutOff && self.$items.length > self.cutOff)self.$container.addClass('scrollable');
-			
+
 			self.getMaxHeight();
-	
+
 			if(self.isTouch && self.nativeTouch){
 				self.bindTouchHandlers();
 			} else {
 				self.bindHandlers();
 			};
 		},
-		
+
 		getMaxHeight: function(){
 			var self = this;
-			
+
 			self.maxHeight = 0;
-			
+
 			for(i = 0; i < self.$items.length; i++){
 				var $item = self.$items.eq(i);
 				self.maxHeight += $item.outerHeight();
@@ -116,7 +116,7 @@
 				};
 			};
 		},
-		
+
 		bindTouchHandlers: function(){
 			var	self = this;
 			self.$container.on('click.easyDropDown',function(){
@@ -127,11 +127,11 @@
 					var	$selected = $(this).find('option:selected'),
 						title = $selected.text(),
 						value = $selected.val();
-						
+
 					self.$active.text(title);
 					if(typeof self.onChange === 'function'){
 						self.onChange.call(self.$select[0],{
-							title: title, 
+							title: title,
 							value: value
 						});
 					};
@@ -144,7 +144,7 @@
 				}
 			});
 		},
-	
+
 		bindHandlers: function(){
 			var	self = this;
 			self.query = '';
@@ -162,7 +162,7 @@
 					};
 				}
 			});
-			
+
 			$('body').on('click.easyDropDown.'+self.id,function(e){
 				var $target = $(e.target),
 					classNames = self.wrapperClass.split(' ').join('.');
@@ -253,7 +253,7 @@
 					},1200);
 				}
 			});
-			
+
 			self.$dropDown.on('scroll.easyDropDown',function(e){
 				if(self.$dropDown[0].scrollTop >= self.$dropDown[0].scrollHeight - self.maxHeight){
 					self.$container.addClass('bottom');
@@ -261,7 +261,7 @@
 					self.$container.removeClass('bottom');
 				};
 			});
-			
+
 			if(self.$form.length){
 				self.$form.on('reset.easyDropDown', function(){
 					var active = self.hasLabel ? self.label : self.options[0].title;
@@ -269,10 +269,10 @@
 				});
 			};
 		},
-		
+
 		unbindHandlers: function(){
 			var self = this;
-			
+
 			self.$container
 				.add(self.$select)
 				.add(self.$items)
@@ -281,7 +281,7 @@
 				.off('.easyDropDown');
 			$('body').off('.'+self.id);
 		},
-		
+
 		open: function(){
 			var self = this,
 				scrollTop = window.scrollY || document.documentElement.scrollTop,
@@ -296,7 +296,7 @@
 			self.$scrollWrapper.css('height',self.maxHeight+'px');
 			self.down = true;
 		},
-		
+
 		close: function(){
 			var self = this;
 			self.$container.removeClass('open');
@@ -305,7 +305,7 @@
 			self.query = '';
 			self.down = false;
 		},
-		
+
 		closeAll: function(){
 			var self = this,
 				instances = Object.getPrototypeOf(self).instances;
@@ -314,14 +314,14 @@
 				instance.close();
 			};
 		},
-	
+
 		select: function(index){
 			var self = this;
-			
+
 			if(typeof index === 'string'){
 				index = self.$select.find('option[value='+index+']').index() - 1;
 			};
-			
+
 			var	option = self.options[index],
 				selectIndex = self.hasLabel ? index + 1 : index;
 			self.$items.removeClass('active').eq(index).addClass('active');
@@ -333,7 +333,7 @@
 				.prop('selected',true)
 				.parent()
 				.trigger('change');
-				
+
 			self.selected = {
 				index: index,
 				title: option.title
@@ -341,23 +341,23 @@
 			self.focusIndex = i;
 			if(typeof self.onChange === 'function'){
 				self.onChange.call(self.$select[0],{
-					title: option.title, 
+					title: option.title,
 					value: option.value
 				});
 			};
 		},
-		
+
 		search: function(){
 			var self = this,
 				lock = function(i){
 					self.focusIndex = i;
 					self.$items.removeClass('focus').eq(self.focusIndex).addClass('focus');
-					self.scrollToView();	
+					self.scrollToView();
 				},
 				getTitle = function(i){
 					return self.options[i].title.toUpperCase();
 				};
-				
+
 			for(i = 0; i < self.options.length; i++){
 				var title = getTitle(i);
 				if(title.indexOf(self.query) == 0){
@@ -365,7 +365,7 @@
 					return;
 				};
 			};
-			
+
 			for(i = 0; i < self.options.length; i++){
 				var title = getTitle(i);
 				if(title.indexOf(self.query) > -1){
@@ -374,17 +374,17 @@
 				};
 			};
 		},
-		
+
 		scrollToView: function(){
 			var self = this;
 			if(self.focusIndex >= self.cutOff){
 				var $focusItem = self.$items.eq(self.focusIndex),
 					scroll = ($focusItem.outerHeight() * (self.focusIndex + 1)) - self.maxHeight;
-			
+
 				self.$dropDown.scrollTop(scroll);
 			};
 		},
-		
+
 		notInViewport: function(scrollTop){
 			var self = this,
 				range = {
@@ -392,14 +392,14 @@
 					max: scrollTop + (window.innerHeight || document.documentElement.clientHeight)
 				},
 				menuBottom = self.$dropDown.offset().top + self.maxHeight;
-				
+
 			if(menuBottom >= range.min && menuBottom <= range.max){
 				return 0;
 			} else {
 				return (menuBottom - range.max) + 5;
 			};
 		},
-		
+
 		destroy: function(){
 			var self = this;
 			self.unbindHandlers();
@@ -407,7 +407,7 @@
 			self.$select.unwrap();
 			delete Object.getPrototypeOf(self).instances[self.$select[0].id];
 		},
-		
+
 		disable: function(){
 			var self = this;
 			self.disabled = true;
@@ -415,7 +415,7 @@
 			self.$select.attr('disabled',true);
 			if(!self.down)self.close();
 		},
-		
+
 		enable: function(){
 			var self = this;
 			self.disabled = false;
@@ -423,7 +423,7 @@
 			self.$select.attr('disabled',false);
 		}
 	};
-	
+
 	var instantiate = function(domNode, settings){
 			domNode.id = !domNode.id ? 'EasyDropDown'+rand() : domNode.id;
 			var instance = new EasyDropDown();
@@ -435,12 +435,12 @@
 		rand = function(){
 			return ('00000'+(Math.random()*16777216<<0).toString(16)).substr(-6).toUpperCase();
 		};
-	
+
 	$.fn.easyDropDown = function(){
 		var args = arguments,
 			dataReturn = [],
 			eachReturn;
-			
+
 		eachReturn = this.each(function(){
 			if(args && typeof args[0] === 'string'){
 				var data = EasyDropDown.prototype.instances[this.id][args[0]](args[1], args[2]);
@@ -449,14 +449,14 @@
 				instantiate(this, args[0]);
 			};
 		});
-		
+
 		if(dataReturn.length){
 			return dataReturn.length > 1 ? dataReturn : dataReturn[0];
 		} else {
 			return eachReturn;
 		};
 	};
-	
+
 	$(function(){
 		if(typeof Object.getPrototypeOf !== 'function'){
 			if(typeof 'test'.__proto__ === 'object'){
@@ -469,10 +469,10 @@
 				};
 			};
 		};
-		
+
 		$('select.dropdown').each(function(){
 			var json = $(this).attr('data-settings');
-				settings = json ? $.parseJSON(json) : {}; 
+				settings = json ? $.parseJSON(json) : {};
 			instantiate(this, settings);
 		});
 	});

--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -176,7 +176,6 @@
 				'click.easyDropDown': function(){
 					var index = $(this).index();
 					self.select(index);
-					self.$select.focus();
 				},
 				'mouseover.easyDropDown': function(){
 					if(!self.keyboardMode){


### PR DESCRIPTION
Hello!

I used your plugin recently and I really like it. Awesome work on it.

I had a very minor bug that I had to fix myself and that's what this pull request is all about.

When you click on a list item, the select element blur method, which removes the `focus` class, is fired before the item element click method, which adds the `focus` class again. This causes the select element to have a `focus` class until the user clicks somewhere else, which means it's no longer in it's initial state. Visually we can see this most clearly on the metro design demo:

![Focus issue](http://i.imgur.com/klJcCjh.png)

So, assuming we want to blur the select when an item is selected, we don't need to call the focus method again on item click. In that way, once you've selected your option, the cycle is over and you're back to initial state.

I also trimmed some whitespaces, there were plenty of them.

Thanks for the great plugin once more.

Regards,
Alexander
