### PR TITLE
Added an option to automatical flag the first empty option as a label

### DIFF
--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -21,6 +21,7 @@
 		this.keyboardMode = false,
 		this.nativeTouch = true,
 		this.wrapperClass = 'dropdown',
+    this.labelEmpty = false,
 		this.onChange = null;
 	};
 	
@@ -50,7 +51,7 @@
 						}
 						self.focusIndex = i;
 					};
-					if($option.hasClass('label') && i == 0){
+          if(($option.hasClass('label') || ($option.val() == "" && self.labelEmpty)) && i == 0){
 						self.hasLabel = true;
 						self.label = $option.text();
 						$option.attr('value','');


### PR DESCRIPTION
Added a setting that will automatically set the first empty option in a drop down to a label. 

I needed this to work with the date_select drop down in rails when the prompt option is used. There didn't seem to be a way to specific a class on an option level for that particular helper. 

It's a specific use case but might be helpful to others. 
