### PR TITLE
Add existing classes and fix jshint errors

### DIFF
--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -10,6 +10,7 @@
 
 
 (function($){
+	'use strict';
 
 	function EasyDropDown(){
 		this.isField = true,
@@ -22,7 +23,7 @@
 		this.nativeTouch = true,
 		this.wrapperClass = 'dropdown',
 		this.onChange = null;
-	};
+	}
 
 	EasyDropDown.prototype = {
 		constructor: EasyDropDown,
@@ -39,7 +40,7 @@
 			self.$select.removeClass(self.wrapperClass+' dropdown');
 			if(self.$select.is(':disabled')){
 				self.disabled = true;
-			};
+			}
 			if(self.$options.length){
 				self.$options.each(function(i){
 					var $option = $(this);
@@ -47,10 +48,10 @@
 						self.selected = {
 							index: i,
 							title: $option.text()
-						}
+						};
 						self.focusIndex = i;
-					};
-					if($option.hasClass('label') && i == 0){
+					}
+					if($option.hasClass('label') && i === 0){
 						self.hasLabel = true;
 						self.label = $option.text();
 						$option.attr('value','');
@@ -61,17 +62,17 @@
 							value: $option.val(),
 							selected: $option.is(':selected')
 						});
-					};
+					}
 				});
 				if(!self.selected){
 					self.selected = {
 						index: 0,
 						title: self.$options.eq(0).text()
-					}
+					};
 					self.focusIndex = 0;
-				};
+				}
 				self.render();
-			};
+			}
 		},
 
 		render: function(){
@@ -100,7 +101,7 @@
 				self.bindTouchHandlers();
 			} else {
 				self.bindHandlers();
-			};
+			}
 		},
 
 		getMaxHeight: function(){
@@ -111,10 +112,10 @@
 			for(i = 0; i < self.$items.length; i++){
 				var $item = self.$items.eq(i);
 				self.maxHeight += $item.outerHeight();
-				if(self.cutOff == i+1){
+				if(self.cutOff === i+1){
 					break;
-				};
-			};
+				}
+			}
 		},
 
 		bindTouchHandlers: function(){
@@ -134,7 +135,7 @@
 							title: title,
 							value: value
 						});
-					};
+					}
 				},
 				focus: function(){
 					self.$container.addClass('focus');
@@ -154,12 +155,12 @@
 						self.open();
 					} else {
 						self.close();
-					};
+					}
 				},
 				'mousemove.easyDropDown': function(){
 					if(self.keyboardMode){
 						self.keyboardMode = false;
-					};
+					}
 				}
 			});
 
@@ -169,7 +170,7 @@
 
 				if(!$target.closest('.'+classNames).length && self.down){
 					self.close();
-				};
+				}
 			});
 
 			self.$items.on({
@@ -183,12 +184,12 @@
 						var $t = $(this);
 						$t.addClass('focus').siblings().removeClass('focus');
 						self.focusIndex = $t.index();
-					};
+					}
 				},
 				'mouseout.easyDropDown': function(){
 					if(!self.keyboardMode){
 						$(this).removeClass('focus');
-					};
+					}
 				}
 			});
 
@@ -209,21 +210,21 @@
 						if(key == 38 || key == 40 || key == 32){
 							e.preventDefault();
 							if(key == 38){
-								self.focusIndex--
+								self.focusIndex--;
 								self.focusIndex = self.focusIndex < 0 ? self.$items.length - 1 : self.focusIndex;
 							} else if(key == 40){
-								self.focusIndex++
+								self.focusIndex++;
 								self.focusIndex = self.focusIndex > self.$items.length - 1 ? 0 : self.focusIndex;
-							};
+							}
 							if(!self.down){
 								self.open();
-							};
+							}
 							self.$items.removeClass('focus').eq(self.focusIndex).addClass('focus');
 							if(self.cutOff){
 								self.scrollToView();
-							};
+							}
 							self.query = '';
-						};
+						}
 						if(self.down){
 							if(key == 9 || key == 27){
 								self.close();
@@ -243,9 +244,9 @@
 								self.query += letter;
 								self.search();
 								clearTimeout(self.resetQuery);
-							};
-						};
-					};
+							}
+						}
+					}
 				},
 				'keyup.easyDropDown': function(){
 					self.resetQuery = setTimeout(function(){
@@ -259,7 +260,7 @@
 					self.$container.addClass('bottom');
 				} else {
 					self.$container.removeClass('bottom');
-				};
+				}
 			});
 
 			if(self.$form.length){
@@ -267,7 +268,7 @@
 					var active = self.hasLabel ? self.label : self.options[0].title;
 					self.$active.text(active);
 				});
-			};
+			}
 		},
 
 		unbindHandlers: function(){
@@ -312,7 +313,7 @@
 			for(var key in instances){
 				var instance = instances[key];
 				instance.close();
-			};
+			}
 		},
 
 		select: function(index){
@@ -320,7 +321,7 @@
 
 			if(typeof index === 'string'){
 				index = self.$select.find('option[value='+index+']').index() - 1;
-			};
+			}
 
 			var	option = self.options[index],
 				selectIndex = self.hasLabel ? index + 1 : index;
@@ -344,7 +345,7 @@
 					title: option.title,
 					value: option.value
 				});
-			};
+			}
 		},
 
 		search: function(){
@@ -360,19 +361,19 @@
 
 			for(i = 0; i < self.options.length; i++){
 				var title = getTitle(i);
-				if(title.indexOf(self.query) == 0){
+				if(title.indexOf(self.query) === 0){
 					lock(i);
 					return;
-				};
-			};
+				}
+			}
 
 			for(i = 0; i < self.options.length; i++){
 				var title = getTitle(i);
 				if(title.indexOf(self.query) > -1){
 					lock(i);
 					break;
-				};
-			};
+				}
+			}
 		},
 
 		scrollToView: function(){
@@ -382,7 +383,7 @@
 					scroll = ($focusItem.outerHeight() * (self.focusIndex + 1)) - self.maxHeight;
 
 				self.$dropDown.scrollTop(scroll);
-			};
+			}
 		},
 
 		notInViewport: function(scrollTop){
@@ -397,7 +398,7 @@
 				return 0;
 			} else {
 				return (menuBottom - range.max) + 5;
-			};
+			}
 		},
 
 		destroy: function(){
@@ -429,7 +430,7 @@
 			var instance = new EasyDropDown();
 			if(!instance.instances[domNode.id]){
 				instance.instances[domNode.id] = instance;
-			};
+			}
 			instance.init(domNode, settings);
 		},
 		rand = function(){
@@ -447,14 +448,14 @@
 				if(data)dataReturn.push(data);
 			} else {
 				instantiate(this, args[0]);
-			};
+			}
 		});
 
 		if(dataReturn.length){
 			return dataReturn.length > 1 ? dataReturn : dataReturn[0];
 		} else {
 			return eachReturn;
-		};
+		}
 	};
 
 	$(function(){
@@ -467,8 +468,8 @@
 				Object.getPrototypeOf = function(object){
 					return object.constructor.prototype;
 				};
-			};
-		};
+			}
+		}
 
 		$('select.dropdown').each(function(){
 			var json = $(this).attr('data-settings');

--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -38,6 +38,7 @@
 			self.$options = self.$select.find('option');
 			self.isTouch = 'ontouchend' in document;
 			self.$select.removeClass(self.wrapperClass+' dropdown');
+            self.extraClasses = self.$select.attr('class');
 			if(self.$select.is(':disabled')){
 				self.disabled = true;
 			}
@@ -78,9 +79,10 @@
 		render: function(){
 			var	self = this,
 				touchClass = self.isTouch && self.nativeTouch ? ' touch' : '',
-				disabledClass = self.disabled ? ' disabled' : '';
+				disabledClass = self.disabled ? ' disabled' : '',
+                extraClasses = self.extraClasses ? ' ' + self.extraClasses : '';
 
-			self.$container = self.$select.wrap('<div class="'+self.wrapperClass+touchClass+disabledClass+'"><span class="old"/></div>').parent().parent();
+			self.$container = self.$select.wrap('<div class="'+self.wrapperClass+touchClass+disabledClass+extraClasses+'"><span class="old"/></div>').parent().parent();
 			self.$active = $('<span class="selected">'+self.selected.title+'</span>').appendTo(self.$container);
 			self.$carat = $('<span class="carat"/>').appendTo(self.$container);
 			self.$scrollWrapper = $('<div><ul/></div>').appendTo(self.$container);

--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -61,7 +61,8 @@
 							domNode: $option[0],
 							title: $option.text(),
 							value: $option.val(),
-							selected: $option.is(':selected')
+							selected: $option.is(':selected'),
+              classes: $option.attr('class') || ''
 						});
 					}
 				});
@@ -89,9 +90,20 @@
 			self.$dropDown = self.$scrollWrapper.find('ul');
 			self.$form = self.$container.closest('form');
 			$.each(self.options, function(){
-				var	option = this,
-					active = option.selected ? ' class="active"':'';
-				self.$dropDown.append('<li'+active+'>'+option.title+'</li>');
+        var option = this,
+          classes = option.classes.split(' ');
+
+        if (option.selected) {
+          classes.push('active');
+        }
+
+        if (classes.length > 0) {
+          classes = ' class="' + classes.join(' ') + '"';
+        } else {
+          classes = '';
+        }
+
+        self.$dropDown.append('<li'+classes+'>'+option.title+'</li>');
 			});
 			self.$items = self.$dropDown.find('li');
 
@@ -111,7 +123,7 @@
 
 			self.maxHeight = 0;
 
-			for(i = 0; i < self.$items.length; i++){
+			for(var i = 0; i < self.$items.length; i++){
 				var $item = self.$items.eq(i);
 				self.maxHeight += $item.outerHeight();
 				if(self.cutOff === i+1){
@@ -474,7 +486,7 @@
 		}
 
 		$('select.dropdown').each(function(){
-			var json = $(this).attr('data-settings');
+			var json = $(this).attr('data-settings'),
 				settings = json ? $.parseJSON(json) : {};
 			instantiate(this, settings);
 		});

--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -10,7 +10,7 @@
 
 
 (function($){
-	
+
 	function EasyDropDown(){
 		this.isField = true,
 		this.down = false,
@@ -23,13 +23,13 @@
 		this.wrapperClass = 'dropdown',
 		this.onChange = null;
 	};
-	
+
 	EasyDropDown.prototype = {
 		constructor: EasyDropDown,
 		instances: {},
 		init: function(domNode, settings){
 			var	self = this;
-			
+
 			$.extend(self, settings);
 			self.$select = $(domNode);
 			self.id = domNode.id;
@@ -73,12 +73,12 @@
 				self.render();
 			};
 		},
-	
+
 		render: function(){
 			var	self = this,
 				touchClass = self.isTouch && self.nativeTouch ? ' touch' : '',
 				disabledClass = self.disabled ? ' disabled' : '';
-			
+
 			self.$container = self.$select.wrap('<div class="'+self.wrapperClass+touchClass+disabledClass+'"><span class="old"/></div>').parent().parent();
 			self.$active = $('<span class="selected">'+self.selected.title+'</span>').appendTo(self.$container);
 			self.$carat = $('<span class="carat"/>').appendTo(self.$container);
@@ -91,23 +91,23 @@
 				self.$dropDown.append('<li'+active+'>'+option.title+'</li>');
 			});
 			self.$items = self.$dropDown.find('li');
-			
+
 			if(self.cutOff && self.$items.length > self.cutOff)self.$container.addClass('scrollable');
-			
+
 			self.getMaxHeight();
-	
+
 			if(self.isTouch && self.nativeTouch){
 				self.bindTouchHandlers();
 			} else {
 				self.bindHandlers();
 			};
 		},
-		
+
 		getMaxHeight: function(){
 			var self = this;
-			
+
 			self.maxHeight = 0;
-			
+
 			for(i = 0; i < self.$items.length; i++){
 				var $item = self.$items.eq(i);
 				self.maxHeight += $item.outerHeight();
@@ -116,7 +116,7 @@
 				};
 			};
 		},
-		
+
 		bindTouchHandlers: function(){
 			var	self = this;
 			self.$container.on('click.easyDropDown',function(){
@@ -127,11 +127,11 @@
 					var	$selected = $(this).find('option:selected'),
 						title = $selected.text(),
 						value = $selected.val();
-						
+
 					self.$active.text(title);
 					if(typeof self.onChange === 'function'){
 						self.onChange.call(self.$select[0],{
-							title: title, 
+							title: title,
 							value: value
 						});
 					};
@@ -144,7 +144,7 @@
 				}
 			});
 		},
-	
+
 		bindHandlers: function(){
 			var	self = this;
 			self.query = '';
@@ -162,7 +162,7 @@
 					};
 				}
 			});
-			
+
 			$('body').on('click.easyDropDown.'+self.id,function(e){
 				var $target = $(e.target),
 					classNames = self.wrapperClass.split(' ').join('.');
@@ -253,7 +253,7 @@
 					},1200);
 				}
 			});
-			
+
 			self.$dropDown.on('scroll.easyDropDown',function(e){
 				if(self.$dropDown[0].scrollTop >= self.$dropDown[0].scrollHeight - self.maxHeight){
 					self.$container.addClass('bottom');
@@ -261,7 +261,7 @@
 					self.$container.removeClass('bottom');
 				};
 			});
-			
+
 			if(self.$form.length){
 				self.$form.on('reset.easyDropDown', function(){
 					var active = self.hasLabel ? self.label : self.options[0].title;
@@ -269,10 +269,10 @@
 				});
 			};
 		},
-		
+
 		unbindHandlers: function(){
 			var self = this;
-			
+
 			self.$container
 				.add(self.$select)
 				.add(self.$items)
@@ -281,7 +281,7 @@
 				.off('.easyDropDown');
 			$('body').off('.'+self.id);
 		},
-		
+
 		open: function(){
 			var self = this,
 				scrollTop = window.scrollY || document.documentElement.scrollTop,
@@ -296,7 +296,7 @@
 			self.$scrollWrapper.css('height',self.maxHeight+'px');
 			self.down = true;
 		},
-		
+
 		close: function(){
 			var self = this;
 			self.$container.removeClass('open');
@@ -305,7 +305,7 @@
 			self.query = '';
 			self.down = false;
 		},
-		
+
 		closeAll: function(){
 			var self = this,
 				instances = Object.getPrototypeOf(self).instances;
@@ -314,14 +314,14 @@
 				instance.close();
 			};
 		},
-	
+
 		select: function(index){
 			var self = this;
-			
+
 			if(typeof index === 'string'){
 				index = self.$select.find('option[value='+index+']').index() - 1;
 			};
-			
+
 			var	option = self.options[index],
 				selectIndex = self.hasLabel ? index + 1 : index;
 			self.$items.removeClass('active').eq(index).addClass('active');
@@ -333,7 +333,7 @@
 				.prop('selected',true)
 				.parent()
 				.trigger('change');
-				
+
 			self.selected = {
 				index: index,
 				title: option.title
@@ -341,23 +341,23 @@
 			self.focusIndex = i;
 			if(typeof self.onChange === 'function'){
 				self.onChange.call(self.$select[0],{
-					title: option.title, 
+					title: option.title,
 					value: option.value
 				});
 			};
 		},
-		
+
 		search: function(){
 			var self = this,
 				lock = function(i){
 					self.focusIndex = i;
 					self.$items.removeClass('focus').eq(self.focusIndex).addClass('focus');
-					self.scrollToView();	
+					self.scrollToView();
 				},
 				getTitle = function(i){
 					return self.options[i].title.toUpperCase();
 				};
-				
+
 			for(i = 0; i < self.options.length; i++){
 				var title = getTitle(i);
 				if(title.indexOf(self.query) == 0){
@@ -365,7 +365,7 @@
 					return;
 				};
 			};
-			
+
 			for(i = 0; i < self.options.length; i++){
 				var title = getTitle(i);
 				if(title.indexOf(self.query) > -1){
@@ -374,17 +374,17 @@
 				};
 			};
 		},
-		
+
 		scrollToView: function(){
 			var self = this;
 			if(self.focusIndex >= self.cutOff){
 				var $focusItem = self.$items.eq(self.focusIndex),
 					scroll = ($focusItem.outerHeight() * (self.focusIndex + 1)) - self.maxHeight;
-			
+
 				self.$dropDown.scrollTop(scroll);
 			};
 		},
-		
+
 		notInViewport: function(scrollTop){
 			var self = this,
 				range = {
@@ -392,14 +392,14 @@
 					max: scrollTop + (window.innerHeight || document.documentElement.clientHeight)
 				},
 				menuBottom = self.$dropDown.offset().top + self.maxHeight;
-				
+
 			if(menuBottom >= range.min && menuBottom <= range.max){
 				return 0;
 			} else {
 				return (menuBottom - range.max) + 5;
 			};
 		},
-		
+
 		destroy: function(){
 			var self = this;
 			self.unbindHandlers();
@@ -407,7 +407,7 @@
 			self.$select.unwrap();
 			delete Object.getPrototypeOf(self).instances[self.$select[0].id];
 		},
-		
+
 		disable: function(){
 			var self = this;
 			self.disabled = true;
@@ -415,7 +415,7 @@
 			self.$select.attr('disabled',true);
 			if(!self.down)self.close();
 		},
-		
+
 		enable: function(){
 			var self = this;
 			self.disabled = false;
@@ -423,24 +423,24 @@
 			self.$select.attr('disabled',false);
 		}
 	};
-	
+
 	var instantiate = function(domNode, settings){
 			domNode.id = !domNode.id ? 'EasyDropDown'+rand() : domNode.id;
 			var instance = new EasyDropDown();
 			if(!instance.instances[domNode.id]){
 				instance.instances[domNode.id] = instance;
-				instance.init(domNode, settings);
 			};
+			instance.init(domNode, settings);
 		},
 		rand = function(){
 			return ('00000'+(Math.random()*16777216<<0).toString(16)).substr(-6).toUpperCase();
 		};
-	
+
 	$.fn.easyDropDown = function(){
 		var args = arguments,
 			dataReturn = [],
 			eachReturn;
-			
+
 		eachReturn = this.each(function(){
 			if(args && typeof args[0] === 'string'){
 				var data = EasyDropDown.prototype.instances[this.id][args[0]](args[1], args[2]);
@@ -449,14 +449,14 @@
 				instantiate(this, args[0]);
 			};
 		});
-		
+
 		if(dataReturn.length){
 			return dataReturn.length > 1 ? dataReturn : dataReturn[0];
 		} else {
 			return eachReturn;
 		};
 	};
-	
+
 	$(function(){
 		if(typeof Object.getPrototypeOf !== 'function'){
 			if(typeof 'test'.__proto__ === 'object'){
@@ -469,10 +469,10 @@
 				};
 			};
 		};
-		
+
 		$('select.dropdown').each(function(){
 			var json = $(this).attr('data-settings');
-				settings = json ? $.parseJSON(json) : {}; 
+				settings = json ? $.parseJSON(json) : {};
 			instantiate(this, settings);
 		});
 	});


### PR DESCRIPTION
There are two enhancements to this PR:
1. Use existing classes on a select element. Currently, the plugin ditches all of the existing classes on a select element. This PR will allow a user to add classes such as invalid or contrast to the select element and it will carry them over.
2. Fixes jshint errors. Douglas Crockford would be happy.
