### PR TITLE
Update jquery.easydropdown.js

### DIFF
--- a/src/jquery.easydropdown.js
+++ b/src/jquery.easydropdown.js
@@ -319,7 +319,7 @@
 			var self = this;
 			
 			if(typeof index === 'string'){
-				index = self.$select.find('option[value='+index+']').index() - 1;
+				index = self.$select.find('option[value='+index+']').index();
 			};
 			
 			var	option = self.options[index],


### PR DESCRIPTION
the select method with a value (string) as parameter is not looking up for the right index. It was selecting the previous option because of a - 1 on line 322.
