### PR TITLE
fix/firefox-scroll-jump-on-focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Changelog
+Changelog
+=========
+
+## 4.0.5
+
+- Fixes a styling issue with Firefox which caused a long scrolling page to scroll to the top when a dropdown is focused.
 
 ## 4.0.4
 

--- a/demos/themes/beanstalk.css
+++ b/demos/themes/beanstalk.css
@@ -101,8 +101,9 @@
 .edd-select {
     position: absolute;
     opacity: 0;
-    left: -999px;
-    top: -999px;
+    width: 100%;
+    left: -100%;
+    top: 0;
 }
 
 .edd-root-native .edd-select {

--- a/demos/themes/flax.css
+++ b/demos/themes/flax.css
@@ -114,8 +114,9 @@
 .edd-select {
     position: absolute;
     opacity: 0;
-    left: -999px;
-    top: -999px;
+    width: 100%;
+    left: -100%;
+    top: 0;
 }
 
 .edd-root-native .edd-select {

--- a/demos/themes/ivy.css
+++ b/demos/themes/ivy.css
@@ -99,8 +99,9 @@
 .edd-select {
     position: absolute;
     opacity: 0;
-    left: -999px;
-    top: -999px;
+    width: 100%;
+    left: -100%;
+    top: 0;
 }
 
 .edd-root-native .edd-select {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easydropdown",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "A lightweight library for building beautiful styleable select elements",
   "author": "KunkaLabs Limited",
   "private": false,


### PR DESCRIPTION
- Fixes a styling issue with Firefox which caused a long scrolling page to scroll to the top when a dropdown is focused.